### PR TITLE
Adds docker dependency to the deployment

### DIFF
--- a/manifests/cfcr.yml
+++ b/manifests/cfcr.yml
@@ -417,9 +417,9 @@ releases:
   url: https://storage.googleapis.com/kubo-precompiled-releases/cfcr-etcd-1.10.0-ubuntu-xenial-250.23-20190323-004649-490174557.tgz
   version: 1.10.0
 - name: docker
-  sha1: 21f7ccd81260e45f53a1dbf5956d9f51da4343ab
-  url: https://storage.googleapis.com/kubo-precompiled-releases/docker-35.1.0-ubuntu-xenial-250.23-20190323-004259-44693764.tgz
-  version: 35.1.0
+  sha1: e2bb5b8cfa5518b4e2d21f2bfe8b1a778fd6a303
+  url: https://storage.googleapis.com/kubo-precompiled-releases/docker-35.1.1-ubuntu-xenial-250.25-20190326-213558-887832211.tgz
+  version: 35.1.1
 - name: bpm
   sha1: dcf5347e3241c7da54f6c073271927b42eb07c69
   url: https://storage.googleapis.com/kubo-precompiled-releases/bpm-1.0.3-ubuntu-xenial-250.23-20190323-005342-823439643.tgz


### PR DESCRIPTION
[#164498025](https://www.pivotaltracker.com/story/show/164498025)
PKS Flannel Network Gets Out of Sync with Docker Bridge Network (cni0)

Co-authored-by: Sudhindra Rao <surao@pivotal.io>
Co-authored-by: Ivan Mikushin <imikushin@vmware.com>

**What this PR does / why we need it**:
<!--
Why is this PR important? What is the user impact?
-->

**How can this PR be verified?**

**Is there any change in kubo-release?**

**Is there any change in kubo-ci?**

**Does this affect upgrade, or is there any migration required?**

**Which issue(s) this PR fixes:**

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note

```
